### PR TITLE
Escaping spaces in rgb_colors path

### DIFF
--- a/colors/desert-warm-256.vim
+++ b/colors/desert-warm-256.vim
@@ -39,7 +39,7 @@ if version > 580
 endif
 let g:colors_name='desert-warm-256'
 
-exec 'source ' . expand('<sfile>:p:h') . '/rgb_colors'
+exec 'source ' . fnameescape(expand('<sfile>:p:h')) . '/rgb_colors'
 
 if has('gui_running') || &t_Co == 88 || &t_Co == 256
     " functions {{{


### PR DESCRIPTION
# What

* Escapes special characters in filenames when resolving `rgb_colors` bundle sub-directory

# Why

* On cygwin, I was installing my bundles and noticed that vim complains with the following error on install / first open:

```
E172: Only one file name allowed: source /home/Daniel DeSousa/.vim/bundle/desert-warm-256/colors/rgb_colors
```

It seems to be caused by the space in my home directory as auto-generated by cygwin to match my NT user. 

I haven't tested this on my other environments but the command should be safe.